### PR TITLE
Destroy necessary activity once navigate to another

### DIFF
--- a/app/src/main/java/com/team3000/logit/BaseActivity.java
+++ b/app/src/main/java/com/team3000/logit/BaseActivity.java
@@ -115,6 +115,7 @@ public abstract class BaseActivity extends AppCompatActivity
 
         } else if (id == R.id.nav_calendar) {
             startActivity(new Intent(BaseActivity.this, CalendarActivity.class));
+            finish(); // destroy the current activity after finish
         } else if (id == R.id.nav_collections) {
 
         } else if (id == R.id.nav_eisen) {
@@ -128,7 +129,7 @@ public abstract class BaseActivity extends AppCompatActivity
         } else if (id == R.id.nav_signOut) {
             mAuth.signOut();
             startActivity(new Intent(this, LoginActivity.class));
-            finish(); // destroy this activity
+            finish(); // destroy the current activity after finish
         }
 
         DrawerLayout drawer = findViewById(R.id.drawer_layout);

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="colorPrimary">#008577</color>
-    <color name="colorPrimaryDark">#00574B</color>
+    <color name="colorPrimary">#03a9f4</color>
+    <color name="colorPrimaryDark">#0288d1</color>
     <color name="colorAccent">#D81B60</color>
 </resources>


### PR DESCRIPTION
Perform this when clicking on the items in navigation drawer for smoother user experience.