### PR TITLE
Partial Navigation fix

### DIFF
--- a/app/src/main/java/com/team3000/logit/ActivityStackManager.java
+++ b/app/src/main/java/com/team3000/logit/ActivityStackManager.java
@@ -1,0 +1,9 @@
+package com.team3000.logit;
+
+import android.app.Activity;
+
+import java.util.Stack;
+
+public class ActivityStackManager {
+    public static Stack<Activity> activityStack = new Stack<>();
+}

--- a/app/src/main/java/com/team3000/logit/BaseActivity.java
+++ b/app/src/main/java/com/team3000/logit/BaseActivity.java
@@ -5,7 +5,6 @@ import android.app.Fragment;
 import android.app.FragmentTransaction;
 import android.content.Intent;
 import android.os.Bundle;
-import android.transition.Transition;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;

--- a/app/src/main/java/com/team3000/logit/BaseActivity.java
+++ b/app/src/main/java/com/team3000/logit/BaseActivity.java
@@ -1,9 +1,12 @@
 package com.team3000.logit;
 
+import android.app.Activity;
 import android.app.Fragment;
 import android.app.FragmentTransaction;
 import android.content.Intent;
 import android.os.Bundle;
+import android.transition.Transition;
+import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -20,13 +23,18 @@ import com.google.android.material.navigation.NavigationView;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseUser;
 
+import java.util.Stack;
+
 public abstract class BaseActivity extends AppCompatActivity
         implements NavigationView.OnNavigationItemSelectedListener {
+    protected static Stack<Activity> activityStack = new Stack<>();
+    protected int currPosition; // indicates which activity of the navigation drawer that the user is currently at
     private FirebaseAuth mAuth;
     protected FirebaseUser user;
     protected Button noteButton;
     protected Button taskButton;
     protected Button eventButton;
+    protected boolean notAtDrawerOptions;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -49,6 +57,7 @@ public abstract class BaseActivity extends AppCompatActivity
         drawer.addDrawerListener(toggle);
         toggle.syncState();
         navigationView.setNavigationItemSelectedListener(this);
+        // this.currPosition = R.id.base_activity; // overriden in some children classes
 
         // Set the text of the welcome message in the navigation drawer
         View header = navigationView.getHeaderView(0);
@@ -111,35 +120,60 @@ public abstract class BaseActivity extends AppCompatActivity
     public boolean onNavigationItemSelected(MenuItem item) {
         // Handle navigation view item clicks here.
         int id = item.getItemId();
+        DrawerLayout drawer = findViewById(R.id.drawer_layout);
 
-        if (id == R.id.nav_today) {
-            Intent intentToday = new Intent(BaseActivity.this, DailyLogActivity.class);
-            intentToday.putExtra("year", 0);
-            finish();
-            startActivity(intentToday);
-        } else if (id == R.id.nav_this_month) {
-            Intent intentThisMonth = new Intent(BaseActivity.this, MonthlyLogActivity.class);
-            intentThisMonth.putExtra("year", 0);
-            finish();
-            startActivity(intentThisMonth);
-        } else if (id == R.id.nav_calendar) {
-            startActivity(new Intent(BaseActivity.this, CalendarActivity.class));
-            finish();
-        } else if (id == R.id.new_collection){
+        // Prevent app from sending intent to the same current activity when user click on the option
+        // which matches current activity
+        if (id == currPosition) {
+            drawer.closeDrawer(GravityCompat.START);
+            return false;
+        }
+
+        if (id == R.id.new_collection) {
             showNewCollectionDialog();
+            return true;
+        }
+
+        Intent intent = null;
+        if (id == R.id.nav_today) {
+            intent = new Intent(BaseActivity.this, DailyLogActivity.class)
+                    .putExtra("year", 0);
+
+        } else if (id == R.id.nav_this_month) {
+            intent = new Intent(BaseActivity.this, MonthlyLogActivity.class)
+                    .putExtra("year", 0);
+
+        } else if (id == R.id.nav_calendar) {
+            intent = new Intent(BaseActivity.this, CalendarActivity.class);
 
         } else if (id == R.id.nav_collections) {
-            startActivity(new Intent(BaseActivity.this, CollectionListActivity.class));
-            finish();   // destroy the current activity after finish
+            intent = new Intent(BaseActivity.this, CollectionListActivity.class);
+
         } else if (id == R.id.nav_eisen) {
 
         } else if (id == R.id.nav_signOut) {
             mAuth.signOut();
-            startActivity(new Intent(this, LoginActivity.class));
-            finish(); // destroy the current activity after finish
+            intent = new Intent(this, LoginActivity.class);
         }
 
-        DrawerLayout drawer = findViewById(R.id.drawer_layout);
+        // intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
+
+        /*
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK)
+            .addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
+        */
+
+        startActivity(intent);
+        finish();
+        if (notAtDrawerOptions) {
+            Log.i("BaseActivity", "In clearing stack");
+            int size = activityStack.size();
+            for (int i = 0; i < size; i++) {
+                Activity activity = activityStack.pop();
+                activity.finish();
+            }
+        }
         drawer.closeDrawer(GravityCompat.START);
         return true;
     }

--- a/app/src/main/java/com/team3000/logit/CalendarActivity.java
+++ b/app/src/main/java/com/team3000/logit/CalendarActivity.java
@@ -17,6 +17,8 @@ public class CalendarActivity extends BaseActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        super.currPosition = R.id.nav_calendar;
+
         FrameLayout contentFrameLayout = findViewById(R.id.content_frame);
         getLayoutInflater().inflate(R.layout.activity_calendar, contentFrameLayout);
 

--- a/app/src/main/java/com/team3000/logit/CollectionActivity.java
+++ b/app/src/main/java/com/team3000/logit/CollectionActivity.java
@@ -13,6 +13,7 @@ public class CollectionActivity extends BaseActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        super.notAtDrawerOptions = true;
 
         // Load the content of the frame layout accordingly.
         // The frame layout serves as a container for the content you want to put.
@@ -27,6 +28,11 @@ public class CollectionActivity extends BaseActivity {
 
         TabLayout tabs = findViewById(R.id.tabs);
         tabs.setupWithViewPager(mPager);
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
     }
 
     @Override

--- a/app/src/main/java/com/team3000/logit/CollectionListActivity.java
+++ b/app/src/main/java/com/team3000/logit/CollectionListActivity.java
@@ -22,6 +22,8 @@ public class CollectionListActivity extends BaseActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        super.currPosition = R.id.nav_collections;
+
         FrameLayout contentFrame = (FrameLayout) findViewById(R.id.content_frame);
         getLayoutInflater().inflate(R.layout.activity_collection_list, contentFrame);
 
@@ -58,6 +60,7 @@ public class CollectionListActivity extends BaseActivity {
             Intent i = new Intent(CollectionListActivity.this, CollectionActivity.class)
                     .putExtra("collection_name", title);
             startActivity(i);
+            activityStack.push(CollectionListActivity.this);
         }));
 
         RecyclerView list = findViewById(R.id.collections_list);

--- a/app/src/main/java/com/team3000/logit/DailyLogActivity.java
+++ b/app/src/main/java/com/team3000/logit/DailyLogActivity.java
@@ -17,6 +17,12 @@ public class DailyLogActivity extends BaseLogActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        // For today's daily log
+        if (getIntent().getIntExtra("year", 1) == 0) {
+            super.currPosition = R.id.nav_today;
+        }
+
         logDate = String.format(Locale.US, "%d %s %d", day, month, year);
         getSupportActionBar().setTitle(logDate);
 

--- a/app/src/main/java/com/team3000/logit/EntryManager.java
+++ b/app/src/main/java/com/team3000/logit/EntryManager.java
@@ -58,8 +58,7 @@ public class EntryManager {
                             } else {
                                 Log.i(TAG, "Fail to delete from collection!");
                             }
-
-                            activity.startActivity(new Intent(activity, DailyLogActivity.class));
+                            activity.finish();
                         });
                     }
                 }));

--- a/app/src/main/java/com/team3000/logit/LoginActivity.java
+++ b/app/src/main/java/com/team3000/logit/LoginActivity.java
@@ -149,7 +149,11 @@ public class LoginActivity extends AppCompatActivity {
     }
 
     private void updateUI() {
-        startActivity(new Intent(this, DailyLogActivity.class));
+        // Extra is put so that when the user clicks on today in drawer they won't be redirected to
+        // the same page again after they signed in and landed in the today's daily log page
+        Intent intentToday = new Intent(LoginActivity.this, DailyLogActivity.class)
+                .putExtra("year", 0);
+        startActivity(intentToday);
         finish(); // destroy this activity
     }
 }

--- a/app/src/main/java/com/team3000/logit/MonthlyLogActivity.java
+++ b/app/src/main/java/com/team3000/logit/MonthlyLogActivity.java
@@ -14,6 +14,12 @@ public class MonthlyLogActivity extends BaseLogActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        // Prevent redirection of the same page when the user click on this month in the drawer
+        if (getIntent().getIntExtra("year", 1) == 0) {
+            super.currPosition = R.id.nav_this_month;
+        }
+
         String logMonth = String.format(Locale.US, "%s %d", month.toUpperCase(), year);
         getSupportActionBar().setTitle(logMonth);
         mPager = findViewById(R.id.log_pager);

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item type = "id" name = "base_activity"/>
+</resources>


### PR DESCRIPTION
Prevent repeated launching of the same activity when clicking on the options in the navigation drawer. Partially fix the navigation issue of the app by clearing the history stack of activities accordingly.